### PR TITLE
fix: properly handle arrays in uses_data

### DIFF
--- a/lib/json_logic.rb
+++ b/lib/json_logic.rb
@@ -29,6 +29,8 @@ module JSONLogic
           collection.concat(uses_data(val))
         }
       end
+    elsif logic.is_a?(Array)
+      logic.each { |val| collection.concat(uses_data(val)) }
     end
 
     return collection.uniq

--- a/test/json_logic_test.rb
+++ b/test/json_logic_test.rb
@@ -87,7 +87,7 @@ class JSONLogicTest < Minitest::Test
       },
       { "x" => "foo"}
     )
-    
+
     assert_equal false, JSONLogic.apply(
       {
         "in" => [
@@ -110,14 +110,25 @@ class JSONLogicTest < Minitest::Test
     )
   end
 
+  def test_uses_data_array
+    assert_equal ["a", "x", "y", "z"], JSONLogic.uses_data(
+      {
+        "in" => [
+          [ { "var" => "a" }, { "var" => "x" } ],
+          [ { "var" => "y" }, { "var" => "z" } ]
+        ]
+      }
+    )
+  end
+
   def test_uses_data_complex
     assert_equal ["temp", "pie.filling"], JSONLogic.uses_data(
       {
         "and" => [
-          {"<" => [ { "var" => "temp" }, 110 ]},  
-          {"==" => [ { "var" => "pie.filling" }, "apple" ]}  
+          {"<" => [ { "var" => "temp" }, 110 ]},
+          {"==" => [ { "var" => "pie.filling" }, "apple" ]}
         ]
-      }   
+      }
     )
   end
 


### PR DESCRIPTION
a json logic rule is a hash with a single operator key, and a values array of 2 elements. example:
```
{ '=': [1, 2] }
```

for some operators, the values array elements can be nested arrays to signify multiple values. e.g.
```
{ 'contains': [[1, 2, 3], [1, 2]]}
```

furthermore, the values can be variables:
```
{ 'contains': [
  { 'var': 'some.array' }, 
  [{ 'var': 'first.element' }, { 'var': 'second.element' }]
]}
```

this array of variables case is not properly supported by the json logic gem since all they do is check if the value element is not an array (see `is_logic` source code), but they don’t actually do anything if it is an array