### PR TITLE
handle nil vars for relevant operators

### DIFF
--- a/lib/json_logic/version.rb
+++ b/lib/json_logic/version.rb
@@ -1,3 +1,3 @@
 module JSONLogic
-  VERSION = '0.4.5'
+  VERSION = '0.4.6.persona'
 end

--- a/test/json_logic_test.rb
+++ b/test/json_logic_test.rb
@@ -154,4 +154,67 @@ class JSONLogicTest < Minitest::Test
     assert_equal ["x"], JSONLogic.apply({"missing": [vars]}, provided_data_missing_x)
   end
 
+  def test_nil_var_substr
+    logic = {"substr" => [{"var" => "test"}, 1]}
+    assert_nil(JSONLogic.apply(logic, {}))
+  end
+
+  def test_nil_var_equals
+    logic = {"=" => [ {"var" => "test"}, 10 ]}
+    assert_nil(JSONLogic.apply(logic, {}))
+
+    logic = {"==" => [ 10, {"var" => "test"} ]}
+    assert_nil(JSONLogic.apply(logic, {}))
+
+    logic = {"===" => [ {"var" => "test"}, 10 ]}
+    assert_nil(JSONLogic.apply(logic, {}))
+
+    logic = {"!=" => [ 10, {"var" => "test"} ]}
+    assert_nil(JSONLogic.apply(logic, {}))
+
+    logic = {"!==" => [ {"var" => "test"}, 10 ]}
+    assert_nil(JSONLogic.apply(logic, {}))
+  end
+
+  def test_nil_var_gt_lt
+    logic = {">" => [ {"var" => "test"}, 10 ]}
+    assert_nil(JSONLogic.apply(logic, {}))
+
+    logic = {">=" => [ 10, {"var" => "test"} ]}
+    assert_nil(JSONLogic.apply(logic, {}))
+
+    logic = {"<" => [ {"var" => "test"}, 10 ]}
+    assert_nil(JSONLogic.apply(logic, {}))
+
+    logic = {"<=" => [ 10, {"var" => "test"} ]}
+    assert_nil(JSONLogic.apply(logic, {}))
+  end
+
+  def test_nil_var_max_min
+    logic = {"max" => [ {"var" => "test"}, 10, 20 ]}
+    assert_nil(JSONLogic.apply(logic, {}))
+
+    logic = {"min" => [ 10, {"var" => "test"}, 20 ]}
+    assert_nil(JSONLogic.apply(logic, {}))
+  end
+
+  def test_nil_var_math_operators
+    logic = {"+" => [ {"var" => "test"}, 10 ]}
+    assert_nil(JSONLogic.apply(logic, {}))
+
+    logic = {"-" => [ 10, {"var" => "test"} ]}
+    assert_nil(JSONLogic.apply(logic, {}))
+
+    logic = {"*" => [ {"var" => "test"}, 10 ]}
+    assert_nil(JSONLogic.apply(logic, {}))
+
+    logic = {"/" => [ 10, {"var" => "test"} ]}
+    assert_nil(JSONLogic.apply(logic, {}))
+
+    logic = {"%" => [ {"var" => "test"}, 10 ]}
+    assert_nil(JSONLogic.apply(logic, {}))
+
+    logic = {"^" => [ 10, {"var" => "test"} ]}
+    assert_nil(JSONLogic.apply(logic, {}))
+  end
 end


### PR DESCRIPTION
1. sync operator changes (we're currently overriding certain operators in our web repo)
2. handle nil vars for certain operators by returning nil

#2 addresses the scenario where nil vars result in unexpected results - e.g. consider the following rule:
```
{ <: [{ var: 'test' }, 10] }
```
currently, if the 'test' var is nil, this still resolves to true because the operator logic for `<` does `to_f` on all the values, resulting in the comparison `0.0 < 10.0`. we're handling this edge case in `evaluate_conditional` by explicitly setting to false whenever a nil var is involved.

why move this change here now? for calculate step we need to leverage the same `evaluate_conditional` method, but currently it assumes the conditional format of ands within ors. calc step can have arbitrarily nested operators in any order, so we won't be able to parse through it and handle this edge case the same way. moving the logic here should support both cases.