### PR TITLE
chore: bump up dependencies version

### DIFF
--- a/json_logic.gemspec
+++ b/json_logic.gemspec
@@ -20,9 +20,9 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.2'
 
-  spec.add_development_dependency 'bundler',  '~> 1.13'
-  spec.add_development_dependency 'rake',     '~> 10.0'
-  spec.add_development_dependency 'minitest', '~> 5.0'
+  spec.add_development_dependency 'bundler',  '>= 2.0.1'
+  spec.add_development_dependency 'rake',     '>= 10.0'
+  spec.add_development_dependency 'minitest', '>= 5.0'
   spec.add_development_dependency 'byebug'
   spec.add_development_dependency 'pry'
   spec.add_runtime_dependency 'backport_dig' if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3')

--- a/lib/json_logic/version.rb
+++ b/lib/json_logic/version.rb
@@ -1,3 +1,3 @@
 module JSONLogic
-  VERSION = '0.4.5.persona'
+  VERSION = '0.4.6.persona'
 end


### PR DESCRIPTION
follows https://github.com/persona-id/json-logic-ruby/blob/master/json_logic.gemspec
- bump up bundler version from 1.13 to 2.0.1
- update dependencies to use >= instead of ~>

also updates the version for a new release