### PR TITLE
fix: fix var traversal when objects switch between array and hash

### DIFF
--- a/lib/core_ext/deep_fetch.rb
+++ b/lib/core_ext/deep_fetch.rb
@@ -3,15 +3,25 @@ require 'backport_dig' if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3
 class Hash
   def deep_fetch(key, default = nil)
     keys = key.to_s.split('.')
-    value = dig(*keys) rescue default
+    value = keys.reduce(self) do |node, k|
+      break default if node.nil?
+      node.is_a?(Array) ? node[k.to_i] : node[k]
+    end
     value.nil? ? default : value  # value can be false (Boolean)
+  rescue
+    default
   end
 end
 
 class Array
-  def deep_fetch(index, default = nil)
-    indexes = index.to_s.split('.').map(&:to_i)
-    value = dig(*indexes) rescue default
+  def deep_fetch(key, default = nil)
+    keys = key.to_s.split('.')
+    value = keys.reduce(self) do |node, k|
+      break default if node.nil?
+      node.is_a?(Array) ? node[k.to_i] : node[k]
+    end
     value.nil? ? default : value  # value can be false (Boolean)
+  rescue
+    default
   end
 end

--- a/lib/json_logic/version.rb
+++ b/lib/json_logic/version.rb
@@ -1,3 +1,3 @@
 module JSONLogic
-  VERSION = '0.4.7.persona'
+  VERSION = '0.4.9.persona'
 end

--- a/test/json_logic_test.rb
+++ b/test/json_logic_test.rb
@@ -154,4 +154,57 @@ class JSONLogicTest < Minitest::Test
     assert_equal ["x"], JSONLogic.apply({"missing": [vars]}, provided_data_missing_x)
   end
 
+  def test_deep_fetch_array_traversal
+    data = { "addresses" => [{ "city" => "Oakland" }, { "city" => "SF" }] }
+    assert_equal "Oakland", data.deep_fetch("addresses.0.city")
+    assert_equal "SF",      data.deep_fetch("addresses.1.city")
+  end
+
+  def test_deep_fetch_array_out_of_bounds_returns_default
+    data = { "addresses" => [{ "city" => "Oakland" }] }
+    assert_nil data.deep_fetch("addresses.9.city")
+    assert_equal "fallback", data.deep_fetch("addresses.9.city", "fallback")
+  end
+
+  def test_deep_fetch_missing_key_returns_default
+    data = { "user" => { "name" => "Alice" } }
+    assert_nil data.deep_fetch("user.age")
+    assert_equal "unknown", data.deep_fetch("user.age", "unknown")
+  end
+
+  def test_deep_fetch_preserves_false_value
+    data = { "flags" => [{ "enabled" => false }] }
+    assert_equal false, data.deep_fetch("flags.0.enabled")
+  end
+
+  def test_var_with_array_traversal
+    logic = { "var" => "addresses.0.city" }
+    data  = { "addresses" => [{ "city" => "Oakland" }] }
+    assert_equal "Oakland", JSONLogic.apply(logic, data)
+  end
+
+  def test_var_with_non_first_array_element
+    logic = { "var" => "addresses.2.city" }
+    data  = { "addresses" => [{ "city" => "Oakland" }, { "city" => "SF" }, { "city" => "Los Angeles" }] }
+    assert_equal "Los Angeles", JSONLogic.apply(logic, data)
+  end
+
+  def test_var_with_array_data_containing_hashes
+    logic = { "var" => "1.city" }
+    data  = [{ "city" => "Oakland" }, { "city" => "SF" }]
+    assert_equal "SF", JSONLogic.apply(logic, data)
+  end
+
+  def test_var_with_array_data_deeper_nesting
+    logic = { "var" => "0.address.city" }
+    data  = [{ "address" => { "city" => "Oakland" } }]
+    assert_equal "Oakland", JSONLogic.apply(logic, data)
+  end
+
+  def test_var_with_array_data_missing_key_returns_nil
+    logic = { "var" => "0.missing" }
+    data  = [{ "city" => "Oakland" }]
+    assert_nil JSONLogic.apply(logic, data)
+  end
+
 end


### PR DESCRIPTION
How the deep fetch works today assumes that when the object we are performing deep fetch on is an array, then any nested object is also an array. Similarly, when it is done on a hash, it assumes all nested objects are hashes. This assumption causes issues for example when we want to perform json logic to hide a component based on a value in an array field whose items are a hash.

Particularly relevant when using the RepeatableContainer in inquiry flow, and having components inside that container that needs show/hide logic based on the specific array item it was rendered for.

Example of problem:
```
data2 = { "field_values" => { "addresses" => [{ "city" => "SF" }, { "city" => "NY" }] } } 
JSONLogic.apply({ "var" => "field_values.addresses.0.city" }, data2)
# returns nil
nil
```

We want that to be "SF".

Another example:

```
data2 = [{"country": "Canada"}, {"country": "US"}]
JSONLogic.apply({ "var" => "1.country" }, data2)
# returns nil
nil
```

We want that to be "US".

**Potential Risk**

Worst Case Incident: SEV-1

We use json logic in a lot of places in persona-web. A bug here can be very bad, to name one example, workflow conditionals could fail, causing inquiry flows and post-inquiry workflows to get hard blocked.

**AI Usage**
Prompted AI to make the code tweak. Human reviewed closely.

**Testing Strategy**
A bunch of new test cases added.

Will be easier to test more thoroughly once a new release version is created, as in persona-web I can change the version to target the new one, and the PR that bumps up the version is the one where its easier to test all the specs on.